### PR TITLE
Add install target to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,16 @@ ifeq ($(CC),cc)
 CC=${CROSS_COMPILE}gcc
 endif
 
+OUT := qlog
+prefix := /usr/local
+
 linux: clean
-	${CC} $(CFLAGS) $(SOURCES) -o QLog ${LDFLAGS} 
+	${CC} $(CFLAGS) $(SOURCES) -o $(OUT) ${LDFLAGS}
 
 clean:
-	rm -rf   *.o  *~  QLog  
+	rm -rf   *.o  *~  $(OUT)
+
+install:
+	mkdir -p $(DESTDIR)$(prefix)/bin
+	install $(OUT) $(DESTDIR)$(prefix)/bin
+	install -m 755 $(OUT) $(DESTDIR)$(prefix)/bin


### PR DESCRIPTION
Install make target into /usr/local/bin by default, and allow custom DESTDIR path to be provided based on GNU standards. For instance, build with `make DESTDIR=/tmp install` will create /tmp/usr/local/bin and install qlog binary into it with executable permissions.